### PR TITLE
feature - preview guess on hover

### DIFF
--- a/personle-website/src/components/play/MakeGuessController.tsx
+++ b/personle-website/src/components/play/MakeGuessController.tsx
@@ -17,6 +17,8 @@ interface MakeGuessControllerProps {
 	isFreeplay?: boolean;
 	correctPersona: PersonaData;
 	resetOnGiveUp?: () => void;
+	setPreviewPersona: React.Dispatch<React.SetStateAction<PersonaData | null>>;
+	previewPersona: PersonaData | null;
 }
 
 export function MakeGuessController({
@@ -27,7 +29,9 @@ export function MakeGuessController({
 	disabled,
 	isFreeplay,
 	correctPersona,
-	resetOnGiveUp
+	resetOnGiveUp,
+	previewPersona,
+	setPreviewPersona
 }: MakeGuessControllerProps) {
 	const [isTutorialOpen, setIsTutorialOpen] = useState(false);
 	const [isGiveUpOpen, setIsGiveUpOpen] = useState<boolean>(false);
@@ -50,6 +54,8 @@ export function MakeGuessController({
 
 				<MessageBox fromSide="left" className="text-white" deltaWidthRem={1}>
 					<PersonaCombobox
+						previewPersona={previewPersona}
+						setPreviewPersona={setPreviewPersona}
 						disabled={disabled}
 						selectedPersona={selectedPersona}
 						setSelectedPersona={setSelectedPersona}

--- a/personle-website/src/components/play/MakeGuessController.tsx
+++ b/personle-website/src/components/play/MakeGuessController.tsx
@@ -89,6 +89,7 @@ export function MakeGuessController({
 								}
 
 								setSelectedPersona(null);
+								setPreviewPersona(null);
 							}}
 						>
 							Submit guess

--- a/personle-website/src/components/play/PersonaCombobox.tsx
+++ b/personle-website/src/components/play/PersonaCombobox.tsx
@@ -14,9 +14,11 @@ interface PersonaComboboxProps {
 	setSelectedPersona: (data: PersonaData) => void;
 	onSelect?: (data: PersonaData) => void;
 	personaNames: string[];
+	setPreviewPersona: React.Dispatch<React.SetStateAction<PersonaData | null>>;
+	previewPersona: PersonaData | null;
 }
 
-export function PersonaCombobox({ disabled = false, selectedPersona, setSelectedPersona, onSelect, personaNames }: PersonaComboboxProps) {
+export function PersonaCombobox({ disabled = false, selectedPersona, setSelectedPersona, onSelect, personaNames, setPreviewPersona }: PersonaComboboxProps) {
 	const personaDataByName = usePersonaDataByName();
 	const [open, setOpen] = useState(false);
 
@@ -37,6 +39,14 @@ export function PersonaCombobox({ disabled = false, selectedPersona, setSelected
 						onSelect(correspondingPersonaData);
 					}
 				}}
+				onMouseOver={() => {
+					const correspondingPersonaData = personaDataByName[personaName];
+
+					if (!correspondingPersonaData) return;
+
+					setPreviewPersona(correspondingPersonaData);
+				}}
+				onMouseLeave={() => setPreviewPersona(null)}
 			>
 				<IconContext.Provider value={{ className: cn("mr-2 h-4 w-4", selectedPersona?.name === personaName ? "opacity-100" : "opacity-0") }}>
 					<LuCheck />

--- a/personle-website/src/components/play/UserGuessManager.tsx
+++ b/personle-website/src/components/play/UserGuessManager.tsx
@@ -13,6 +13,8 @@ interface UserGuessManagerProps {
 	onSubmitGuess: (guess: PersonaData) => Promise<void> | void;
 	isFreeplay?: boolean;
 	resetOnGiveUp?: () => void;
+	previewPersona: PersonaData | null;
+	setPreviewPersona: React.Dispatch<React.SetStateAction<PersonaData | null>>;
 }
 
 export function UserGuessManager({
@@ -23,7 +25,9 @@ export function UserGuessManager({
 	setSelectedPersona,
 	onSubmitGuess,
 	isFreeplay,
-	resetOnGiveUp
+	resetOnGiveUp,
+	previewPersona,
+	setPreviewPersona
 }: UserGuessManagerProps) {
 	const allPersonaNames = usePersonaNames();
 
@@ -34,6 +38,8 @@ export function UserGuessManager({
 	return (
 		<div>
 			<MakeGuessController
+				previewPersona={previewPersona}
+				setPreviewPersona={setPreviewPersona}
 				isFreeplay={isFreeplay}
 				disabled={disabled}
 				personaNames={possiblePersonaNames}
@@ -44,7 +50,13 @@ export function UserGuessManager({
 				resetOnGiveUp={resetOnGiveUp}
 			/>
 
-			<GuessesTable className="my-8" guesses={guesses} correctPersona={correctPersona} selectedPersona={selectedPersona} />
+			<GuessesTable
+				previewPersona={previewPersona}
+				className="my-8"
+				guesses={guesses}
+				correctPersona={correctPersona}
+				selectedPersona={selectedPersona}
+			/>
 		</div>
 	);
 }

--- a/personle-website/src/components/play/table/GuessesTable.tsx
+++ b/personle-website/src/components/play/table/GuessesTable.tsx
@@ -12,9 +12,10 @@ interface GuessesTableProps {
 	correctPersona: PersonaData;
 	guesses: PersonaData[];
 	className?: string;
+	previewPersona: PersonaData | null;
 }
 
-export function GuessesTable({ selectedPersona, correctPersona, guesses, className }: GuessesTableProps) {
+export function GuessesTable({ selectedPersona, correctPersona, guesses, className, previewPersona }: GuessesTableProps) {
 	const reversedGuesses = useMemo(() => [...guesses].reverse(), [guesses]);
 
 	const isDesktop = useMediaQuery("(min-width: 64rem)");
@@ -34,11 +35,11 @@ export function GuessesTable({ selectedPersona, correctPersona, guesses, classNa
 				</TableHeader>
 
 				<TableBody>
-					{selectedPersona && (
+					{(selectedPersona || previewPersona) && (
 						<GuessesRow
-							key={`guess-result-row-unsubmitted-${selectedPersona.name}`}
+							key={`guess-result-row-unsubmitted-${(previewPersona ?? selectedPersona!).name}`}
 							correctPersona={correctPersona}
-							guessPersona={selectedPersona}
+							guessPersona={previewPersona ?? selectedPersona!}
 							isSubmitted={false}
 						/>
 					)}

--- a/personle-website/src/pages/DailyPlayPage.tsx
+++ b/personle-website/src/pages/DailyPlayPage.tsx
@@ -18,10 +18,19 @@ interface DailyPlayGuessManagerProps {
 	initialGuesses: PersonaData[];
 	correctPersona: PersonaData;
 	selectedPersona: PersonaData | null;
+	previewPersona: PersonaData | null;
 	setSelectedPersona: React.Dispatch<React.SetStateAction<PersonaData | null>>;
+	setPreviewPersona: React.Dispatch<React.SetStateAction<PersonaData | null>>;
 }
 
-function DailyPlayGuessManager({ initialGuesses, correctPersona, selectedPersona, setSelectedPersona }: DailyPlayGuessManagerProps) {
+function DailyPlayGuessManager({
+	initialGuesses,
+	correctPersona,
+	selectedPersona,
+	setSelectedPersona,
+	previewPersona,
+	setPreviewPersona
+}: DailyPlayGuessManagerProps) {
 	const queryClient = useQueryClient();
 	const personaDataByName = usePersonaDataByName();
 
@@ -37,6 +46,8 @@ function DailyPlayGuessManager({ initialGuesses, correctPersona, selectedPersona
 				correctPersona={correctPersona}
 				selectedPersona={selectedPersona}
 				setSelectedPersona={setSelectedPersona}
+				previewPersona={previewPersona}
+				setPreviewPersona={setPreviewPersona}
 				onSubmitGuess={async (guess: PersonaData) => {
 					if (guesses.includes(personaDataByName[guess.name])) return;
 
@@ -46,15 +57,17 @@ function DailyPlayGuessManager({ initialGuesses, correctPersona, selectedPersona
 					setGuesses((prev) => {
 						const newGuesses = [...prev, personaDataByName[guess.name]];
 
-						queryClient.setQueryData(["getDailyGuesses"], (data: GetDailyGuessesResponse): GetDailyGuessesResponse => ({
-							todayPersona: data.todayPersona,
-							guesses: [...data.guesses, guess.name]
-						}));
+						queryClient.setQueryData(
+							["getDailyGuesses"],
+							(data: GetDailyGuessesResponse): GetDailyGuessesResponse => ({
+								todayPersona: data.todayPersona,
+								guesses: [...data.guesses, guess.name]
+							})
+						);
 
 						if (guess.name === correctPersona.name) {
 							setTimeout(() => setIsCorrectGuessDialogOpen(true), 3500);
-						}
-						else if (newGuesses.length >= MAX_DAILY_GUESSES) {
+						} else if (newGuesses.length >= MAX_DAILY_GUESSES) {
 							setTimeout(() => setIsOutOfGuessesDialogOpen(true), 3500);
 						}
 
@@ -93,7 +106,9 @@ export function DailyPlayPage() {
 		queryFn: getDailyGuesses,
 		staleTime: Infinity
 	});
+
 	const [selectedPersona, setSelectedPersona] = useState<PersonaData | null>(null);
+	const [previewPersona, setPreviewPersona] = useState<PersonaData | null>(null);
 
 	return (
 		<>
@@ -119,6 +134,8 @@ export function DailyPlayPage() {
 			) : (
 				data && (
 					<DailyPlayGuessManager
+						setPreviewPersona={setPreviewPersona}
+						previewPersona={previewPersona}
 						correctPersona={personaDataByName[data.todayPersona]}
 						initialGuesses={data.guesses.map((guess) => personaDataByName[guess])}
 						selectedPersona={selectedPersona}

--- a/personle-website/src/pages/FreePlayPage.tsx
+++ b/personle-website/src/pages/FreePlayPage.tsx
@@ -22,6 +22,13 @@ export function FreePlayPage() {
 
 	const [isCorrectGuessDialogOpen, setIsCorrectGuessDialogOpen] = useState(false);
 
+	const [previewPersona, setPreviewPersona] = useState<PersonaData | null>(null);
+
+	const resetPage = () => {
+		setGuesses([]);
+		setCorrectPersona(personaDataByName[unseenPersonaNames[Math.floor(Math.random() * unseenPersonaNames.length)]]);
+	};
+
 	return (
 		<>
 			<DateWithDay className="self-start text-[min(7.5vw,2.5rem)] -rotate-[24deg]" />
@@ -35,6 +42,10 @@ export function FreePlayPage() {
 			</div>
 
 			<UserGuessManager
+				previewPersona={previewPersona}
+				setPreviewPersona={setPreviewPersona}
+				resetOnGiveUp={resetPage}
+				isFreeplay
 				disabled={guesses.includes(correctPersona)}
 				guesses={guesses}
 				correctPersona={correctPersona}
@@ -62,9 +73,7 @@ export function FreePlayPage() {
 							skewMagnitude="none"
 							palette="whiteText"
 							onClick={() => {
-								setGuesses([]);
-								setCorrectPersona(personaDataByName[unseenPersonaNames[Math.floor(Math.random() * unseenPersonaNames.length)]]);
-
+								resetPage();
 								setIsCorrectGuessDialogOpen(false);
 							}}
 						>


### PR DESCRIPTION
## Why?

Quality of life upgrade, you're able to see the demons' attributes while scrolling/hovering the combobox, which helps to understand if it might be a correct guess or not

## How?

Add previewPersona state that is passed to all children

Hovering adds a persona to the state, mouse leave removes it

When state is not falsy (null), it overlaps whatever was selected. When is falsy, the selectedPersona has priority

## Screenshots 📷


https://github.com/user-attachments/assets/506cedb2-2451-4924-b560-326ab1fc3741

